### PR TITLE
Remove showing version interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,18 @@ command = "/path/to/mackerel-plugin-sample"
 
 ### Release by TravisCI
 
-1. `git tag vx.y.z`
-2. git push --tags
-3. Wait to build at https://travis-ci.org/shibayu36/mackerel-plugin-sample
-4. See https://github.com/shibayu36/mackerel-plugin-sample/releases
+1. Edit CHANGELOG.md, git commit, git push
+2. `git tag vx.y.z`
+3. git push --tags
+4. Wait to build at https://travis-ci.org/shibayu36/mackerel-plugin-sample
+5. See https://github.com/shibayu36/mackerel-plugin-sample/releases
 
 Don't forget setting GITHUB_TOKEN as environment variables in TravisCI.  If you don't know how, see https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings .
 
 ### Release by manually
 
 1. Install goxc and ghr by `make setup`
-2. `git tag vx.y.z`
-3. GITHUB_TOKEN=... script/release
-4. See https://github.com/shibayu36/mackerel-plugin-sample/releases
+2. Edit CHANGELOG.md, git commit, git push
+3. `git tag vx.y.z`
+4. GITHUB_TOKEN=... script/release
+5. See https://github.com/shibayu36/mackerel-plugin-sample/releases

--- a/lib/sample.go
+++ b/lib/sample.go
@@ -2,15 +2,12 @@ package mpsample
 
 import (
 	"flag"
-	"fmt"
 	"math/rand"
 	"strings"
 	"time"
 
 	mp "github.com/mackerelio/go-mackerel-plugin"
 )
-
-const version = "0.0.5"
 
 // SamplePlugin mackerel plugin
 type SamplePlugin struct {
@@ -52,14 +49,8 @@ func (p *SamplePlugin) FetchMetrics() (map[string]float64, error) {
 
 // Do the plugin
 func Do() {
-	optVersion := flag.Bool("version", false, "Show version")
 	optPrefix := flag.String("metric-key-prefix", "", "Metric key prefix")
 	flag.Parse()
-
-	if *optVersion {
-		fmt.Println(version)
-		return
-	}
 
 	plugin := mp.NewMackerelPlugin(&SamplePlugin{
 		Prefix: *optPrefix,


### PR DESCRIPTION
This pull request removed showing version interface to make the plugin more simple.

In addition to it, I referred to editing CHANGELOG.md in README.md.  I removed version interface, but I want a plugin's author to write changes explicitly.